### PR TITLE
Uikit main page event

### DIFF
--- a/HelloThere_UIKit/HelloThere_UIKit.xcodeproj/project.pbxproj
+++ b/HelloThere_UIKit/HelloThere_UIKit.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		43388EA32C7331B100E65FEA /* NavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43388EA22C7331B100E65FEA /* NavigationDelegate.swift */; };
+		43388EA62C73341400E65FEA /* MaintenanceMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43388EA52C73341400E65FEA /* MaintenanceMainViewController.swift */; };
+		43388EAB2C7334B800E65FEA /* PostDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43388EAA2C7334B800E65FEA /* PostDetailViewController.swift */; };
+		43388EAE2C73387C00E65FEA /* BoardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43388EAD2C73387C00E65FEA /* BoardListViewController.swift */; };
 		433FA09E2C69C59400AC709F /* TopPartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433FA09D2C69C59400AC709F /* TopPartView.swift */; };
 		433FA0A12C69D2A800AC709F /* HexColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433FA0A02C69D2A800AC709F /* HexColor.swift */; };
 		433FA0A32C69DBF600AC709F /* BoardPartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433FA0A22C69DBF600AC709F /* BoardPartView.swift */; };
@@ -48,6 +52,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		43388EA22C7331B100E65FEA /* NavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDelegate.swift; sourceTree = "<group>"; };
+		43388EA52C73341400E65FEA /* MaintenanceMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceMainViewController.swift; sourceTree = "<group>"; };
+		43388EAA2C7334B800E65FEA /* PostDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewController.swift; sourceTree = "<group>"; };
+		43388EAD2C73387C00E65FEA /* BoardListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListViewController.swift; sourceTree = "<group>"; };
 		433FA09D2C69C59400AC709F /* TopPartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPartView.swift; sourceTree = "<group>"; };
 		433FA0A02C69D2A800AC709F /* HexColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HexColor.swift; sourceTree = "<group>"; };
 		433FA0A22C69DBF600AC709F /* BoardPartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardPartView.swift; sourceTree = "<group>"; };
@@ -100,6 +108,40 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		43388EA12C73317700E65FEA /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				43388EA22C7331B100E65FEA /* NavigationDelegate.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		43388EA42C7333EC00E65FEA /* DetailViews */ = {
+			isa = PBXGroup;
+			children = (
+				43388EA92C73348D00E65FEA /* BoardViews */,
+				43388EA82C73343500E65FEA /* MaintenanceViews */,
+			);
+			path = DetailViews;
+			sourceTree = "<group>";
+		};
+		43388EA82C73343500E65FEA /* MaintenanceViews */ = {
+			isa = PBXGroup;
+			children = (
+				43388EA52C73341400E65FEA /* MaintenanceMainViewController.swift */,
+			);
+			path = MaintenanceViews;
+			sourceTree = "<group>";
+		};
+		43388EA92C73348D00E65FEA /* BoardViews */ = {
+			isa = PBXGroup;
+			children = (
+				43388EAA2C7334B800E65FEA /* PostDetailViewController.swift */,
+				43388EAD2C73387C00E65FEA /* BoardListViewController.swift */,
+			);
+			path = BoardViews;
+			sourceTree = "<group>";
+		};
 		433FA09F2C69D29300AC709F /* CommonUtils */ = {
 			isa = PBXGroup;
 			children = (
@@ -156,6 +198,8 @@
 				43C861032C3D2168008A5A8A /* AppDelegate.swift */,
 				43C861052C3D2168008A5A8A /* SceneDelegate.swift */,
 				43C861072C3D2168008A5A8A /* ViewController.swift */,
+				43388EA42C7333EC00E65FEA /* DetailViews */,
+				43388EA12C73317700E65FEA /* Protocols */,
 				433FA09F2C69D29300AC709F /* CommonUtils */,
 				43D1356F2C6615070024BCB1 /* MainViews */,
 				43C8610C2C3D216B008A5A8A /* Assets.xcassets */,
@@ -331,16 +375,20 @@
 				43C861082C3D2168008A5A8A /* ViewController.swift in Sources */,
 				43C86F2B2C6B38BD002C76C6 /* TabBarCustom.swift in Sources */,
 				433FA0A12C69D2A800AC709F /* HexColor.swift in Sources */,
+				43388EAB2C7334B800E65FEA /* PostDetailViewController.swift in Sources */,
 				433FA0A52C69E96100AC709F /* InteriorPartView.swift in Sources */,
 				43D135772C66161F0024BCB1 /* MyPageViewController.swift in Sources */,
 				433FA0A32C69DBF600AC709F /* BoardPartView.swift in Sources */,
 				43D135712C66154C0024BCB1 /* TabBarController.swift in Sources */,
+				43388EAE2C73387C00E65FEA /* BoardListViewController.swift in Sources */,
 				43D135732C6615D10024BCB1 /* MainPageViewController.swift in Sources */,
+				43388EA32C7331B100E65FEA /* NavigationDelegate.swift in Sources */,
 				43C861042C3D2168008A5A8A /* AppDelegate.swift in Sources */,
 				433FA09E2C69C59400AC709F /* TopPartView.swift in Sources */,
 				436BBF712C661D47006FB717 /* MainPageCommonUtils.swift in Sources */,
 				43C861062C3D2168008A5A8A /* SceneDelegate.swift in Sources */,
 				436BBF742C661DDE006FB717 /* AppBarView.swift in Sources */,
+				43388EA62C73341400E65FEA /* MaintenanceMainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HelloThere_UIKit/HelloThere_UIKit/DetailViews/BoardViews/BoardListViewController.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/DetailViews/BoardViews/BoardListViewController.swift
@@ -1,0 +1,76 @@
+//
+//  BoardListViewController.swift
+//  HelloThere_UIKit
+//
+//  Created by 임정현 on 2024/08/19.
+//
+
+import UIKit
+
+class BoardListViewController: UIViewController {
+    
+    var receivedData: String?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .white
+        
+        let navigationBar = UIView()
+        navigationBar.backgroundColor = .white
+        navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        
+        let backButton = UIButton(type : .system)
+        backButton.setImage(UIImage(systemName: "chevron.left"),for: .normal)
+        backButton.tintColor = UIColor(hexCode: "5D5D5D")
+        backButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        let titleLabel = UILabel()
+        titleLabel.text = receivedData
+        titleLabel.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = UIColor(hexCode: "2BCBA5")
+        titleLabel.sizeToFit()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let stackView = UIStackView(arrangedSubviews: [backButton, titleLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        navigationBar.addSubview(stackView)
+        
+        let label = UILabel()
+        label.text = "게시판 목록 들어올 페이지"
+        label.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .black
+        label.sizeToFit()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(navigationBar)
+        view.addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.heightAnchor.constraint(equalToConstant: 60),
+            
+            stackView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor, constant: 16),
+            stackView.centerYAnchor.constraint(equalTo: navigationBar.centerYAnchor),
+            
+            label.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant : 15)
+        ])
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+}

--- a/HelloThere_UIKit/HelloThere_UIKit/DetailViews/BoardViews/PostDetailViewController.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/DetailViews/BoardViews/PostDetailViewController.swift
@@ -1,0 +1,66 @@
+//
+//  PostDetailViewController.swift
+//  HelloThere_UIKit
+//
+//  Created by 임정현 on 2024/08/19.
+//
+
+import UIKit
+
+class PostDetailViewController: UIViewController {
+    
+    var receivedData: String?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.tabBarController?.tabBar.isHidden = true
+        self.view.backgroundColor = .white
+        
+        let navigationBar = UIView()
+        navigationBar.backgroundColor = .white
+        navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        
+        let backButton = UIButton(type : .system)
+        backButton.setImage(UIImage(systemName: "chevron.left"),for: .normal)
+        backButton.tintColor = UIColor(hexCode: "5D5D5D")
+        backButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        let titleLabel = UILabel()
+        titleLabel.text = receivedData
+        titleLabel.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = UIColor(hexCode: "2BCBA5")
+        titleLabel.sizeToFit()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let stackView = UIStackView(arrangedSubviews: [backButton, titleLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        navigationBar.addSubview(stackView)
+        
+        view.addSubview(navigationBar)
+        
+        NSLayoutConstraint.activate([
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.heightAnchor.constraint(equalToConstant: 60),
+            
+            stackView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor, constant: 16),
+            stackView.centerYAnchor.constraint(equalTo: navigationBar.centerYAnchor)
+        ])
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
+    }
+}

--- a/HelloThere_UIKit/HelloThere_UIKit/DetailViews/MaintenanceViews/MaintenanceMainViewController.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/DetailViews/MaintenanceViews/MaintenanceMainViewController.swift
@@ -1,0 +1,65 @@
+//
+//  MaintenanceMainViewController.swift
+//  HelloThere_UIKit
+//
+//  Created by 임정현 on 2024/08/19.
+//
+
+import UIKit
+
+class MaintenanceMainViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.tabBarController?.tabBar.isHidden = true
+        self.view.backgroundColor = .white
+        
+        let navigationBar = UIView()
+        navigationBar.backgroundColor = .white
+        navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        
+        let backButton = UIButton(type : .system)
+        backButton.setImage(UIImage(systemName: "chevron.left"),for: .normal)
+        backButton.tintColor = UIColor(hexCode: "5D5D5D")
+        backButton.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        let titleLabel = UILabel()
+        titleLabel.text = "이달의 관리비"
+        titleLabel.font = UIFont.systemFont(ofSize: 20, weight: .bold)
+        titleLabel.textColor = UIColor(hexCode: "2BCBA5")
+        titleLabel.sizeToFit()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let stackView = UIStackView(arrangedSubviews: [backButton, titleLabel])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        navigationBar.addSubview(stackView)
+        
+        view.addSubview(navigationBar)
+        
+        NSLayoutConstraint.activate([
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.heightAnchor.constraint(equalToConstant: 60),
+            
+            stackView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor, constant: 16),
+            stackView.centerYAnchor.constraint(equalTo: navigationBar.centerYAnchor)
+        ])
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+}

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViewController.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViewController.swift
@@ -7,13 +7,11 @@
 
 import UIKit
 
-class MainPageViewController: UIViewController {
-    
-    let contentViewFactory = MainPageCommonUtils()
+class MainPageViewController: UIViewController, NavigationDelegate {
     
     let scrollView = UIScrollView()
     let scrollContentView = UIView()
-    //    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -22,28 +20,33 @@ class MainPageViewController: UIViewController {
         // 상단 navigationBar로 인한 빈 공간 없애기
         
         let appBarView = AppBarView()
+        appBarView.isUserInteractionEnabled = true
         view.addSubview(appBarView)
-        //        
+        
         scrollContent()
-        //        
+        
         view.addSubview(scrollView)
         
         let topPartView = TopPartView(contentView: scrollContentView)
+        topPartView.navigationDelegate = self
         topPartView.translatesAutoresizingMaskIntoConstraints = false
         scrollContentView.addSubview(topPartView)
-        //        
+        
         
         let boardPartView = BoardPartView(contentView: scrollContentView, belowView: topPartView)
+        boardPartView.navigationDelegate = self
         boardPartView.translatesAutoresizingMaskIntoConstraints = false
         scrollContentView.addSubview(boardPartView)
         
         
         let interiorPartView = InteriorPartView(contentView: scrollContentView, belowView: boardPartView)
+        interiorPartView.navigateDelegate = self
         interiorPartView.translatesAutoresizingMaskIntoConstraints = false
         scrollContentView.addSubview(interiorPartView)
         
         
         let garageSalePartView = GarageSalePartView(contentView: scrollContentView, belowView: interiorPartView)
+        garageSalePartView.navigateDelegate = self
         garageSalePartView.translatesAutoresizingMaskIntoConstraints = false
         interiorPartView.layer.borderColor = UIColor.systemPink.cgColor
         interiorPartView.layer.borderWidth = 5.0
@@ -55,7 +58,7 @@ class MainPageViewController: UIViewController {
             appBarView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             appBarView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             appBarView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            //            
+            
             scrollView.topAnchor.constraint(equalTo: appBarView.bottomAnchor, constant:10),
             scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
@@ -100,10 +103,33 @@ class MainPageViewController: UIViewController {
         
         scrollView.addSubview(scrollContentView)
     }
+    
+    func navigateToNextPage() {
+        print("nextPage here")
+        
+        let nextViewController = MaintenanceMainViewController()
+        self.navigationController?.pushViewController(nextViewController, animated: false)
+    }
+    
+    func navigateToBoardDetailPage(with title: String) {
+        print("boardDetailPage here")
+        
+        let nextViewController = PostDetailViewController()
+        nextViewController.receivedData = title
+        self.navigationController?.pushViewController(nextViewController, animated: false)
+    }
+    
+    func navigateToBoardListPage(with boardName: String) {
+        print("boardListPage here")
+        
+        let nextViewController = BoardListViewController()
+        nextViewController.receivedData = boardName
+        self.navigationController?.pushViewController(nextViewController, animated: false)
+    }
 }
 
 
 #Preview {
-    let vc = MainPageViewController()
+    let vc = ViewController()
     return vc
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/AppBarView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/AppBarView.swift
@@ -27,7 +27,6 @@ class AppBarView: UIStackView {
         spacing = 10
         translatesAutoresizingMaskIntoConstraints = false
         // autolayout을 사용할 때는 false로 설정
-        //        backgroundColor = .cyan
         
         
         let logoStackView = UIStackView()
@@ -36,7 +35,6 @@ class AppBarView: UIStackView {
         logoStackView.spacing = 10
         logoStackView.distribution = .fillProportionally
         logoStackView.translatesAutoresizingMaskIntoConstraints = false
-        //        logoStackView.backgroundColor = .brown
         
         
         let buttonStackView = UIStackView()
@@ -45,7 +43,6 @@ class AppBarView: UIStackView {
         buttonStackView.spacing = 10
         buttonStackView.distribution = .fillEqually
         buttonStackView.translatesAutoresizingMaskIntoConstraints = false
-        //        buttonStackView.backgroundColor = .orange
         
         let logo = UIImageView()
         logo.image = UIImage(named: "logo_noHand")

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/BoardPartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/BoardPartView.swift
@@ -7,26 +7,26 @@
 
 import UIKit
 
-class BoardPartView: UIView {
+class BoardPartView: UIStackView, UIGestureRecognizerDelegate {
     let utils = MainPageCommonUtils()
+    weak var navigationDelegate : NavigationDelegate?
     
     init(contentView: UIView, belowView: UIView) {
         super.init(frame: .zero)
         setupView(contentView: contentView, belowView: belowView)
     }
     
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupView(contentView: UIView(), belowView: UIView())
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
+    
     private func setupView(contentView: UIView, belowView: UIView) {
-        let boardPartStackView = UIStackView()
-        boardPartStackView.axis = .vertical
-        boardPartStackView.alignment = .leading
-        boardPartStackView.spacing = 20
-        boardPartStackView.distribution = .fillProportionally
-        boardPartStackView.translatesAutoresizingMaskIntoConstraints = false
+        axis = .vertical
+       alignment = .leading
+        spacing = 20
+        distribution = .fillProportionally
+        translatesAutoresizingMaskIntoConstraints = false
         
         let boardListStackView = UIStackView()
         boardListStackView.axis = .vertical
@@ -36,24 +36,39 @@ class BoardPartView: UIView {
         boardListStackView.translatesAutoresizingMaskIntoConstraints = false
         
         
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "자유소통 게시판"))
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "갈등 소통 게시판"))
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "공구/나눔 게시판"))
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "중고장터 게시판"))
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "정보공유 게시판"))
-        boardListStackView.addArrangedSubview(utils.boardList(boardName: "질문 게시판"))
+        let boardNameLists = ["자유소통 게시판", "갈등 소통 게시판", "공구/나눔 게시판", "중고장터 게시판", "정보공유 게시판", "질문 게시판"]
+        
+        for boardName in boardNameLists{
+            let boardNameLabel = utils.boardList(boardName: boardName)
+            
+            boardNameLabel.isUserInteractionEnabled = true
+            let tapGesture = BoardTapGesture(target: self, action: #selector(boardTapped(_:)))
+            tapGesture.data = boardName
+            boardNameLabel.addGestureRecognizer(tapGesture)
+            
+            boardListStackView.addArrangedSubview(boardNameLabel)
+            
+        }
         
         
-        boardPartStackView.addArrangedSubview(utils.boardTitle(partName: "주민 게시판"))
-        boardPartStackView.addArrangedSubview(boardListStackView)
+        self.addArrangedSubview(utils.boardTitle(partName: "주민 게시판"))
+        self.addArrangedSubview(boardListStackView)
         
-        contentView.addSubview(boardPartStackView)
+        contentView.addSubview(self)
         
         NSLayoutConstraint.activate([
-            boardPartStackView.topAnchor.constraint(equalTo: belowView.bottomAnchor, constant: 30),
-            boardPartStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            boardPartStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            boardPartStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -20)
+            self.topAnchor.constraint(equalTo: belowView.bottomAnchor, constant: 30),
+            self.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            self.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            self.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -20)
         ])
+    }
+    
+    @objc func boardTapped(_ sender : BoardTapGesture) {
+        print("board clicked")
+        
+        if let data = sender.data {
+            navigationDelegate?.navigateToBoardListPage(with: data)
+        }
     }
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/GarageSalePartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/GarageSalePartView.swift
@@ -28,7 +28,6 @@ class GarageSalePartView: UIStackView {
         spacing = 20
         distribution = .fillProportionally
         translatesAutoresizingMaskIntoConstraints = false
-        //        garageSaleBoardPart.backgroundColor = .orange
         
         
         let boardTitle = utils.boardTitle(partName: "중고장터")
@@ -37,7 +36,9 @@ class GarageSalePartView: UIStackView {
         tapGesture.data = "중고장터"
         boardTitle.addGestureRecognizer(tapGesture)
         
+        
         self.addArrangedSubview(boardTitle)
+        
         
         let boardScrollView = UIScrollView()
         boardScrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -103,7 +104,7 @@ class GarageSalePartView: UIStackView {
     
     @objc func boardTapped(_ sender : BoardTapGesture) {
         print("board garageSale clicked")
-
+        
         if let data = sender.data {
             navigateDelegate?.navigateToBoardListPage(with: data)
         }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/GarageSalePartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/GarageSalePartView.swift
@@ -7,32 +7,37 @@
 
 import UIKit
 
-class GarageSalePartView: UIView {
+class GarageSalePartView: UIStackView {
     let utils = MainPageCommonUtils()
     let api = RequestApi()
+    weak var navigateDelegate : NavigationDelegate?
     
     init(contentView: UIView, belowView: UIView) {
         super.init(frame: .zero)
         setupView(contentView: contentView, belowView: belowView)
     }
     
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupView(contentView: UIView(), belowView: UIView())
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
+    
     private func setupView(contentView: UIView, belowView: UIView) {
-        let garageSaleBoardPart = UIStackView()
-        garageSaleBoardPart.axis = .vertical
-        garageSaleBoardPart.alignment = .leading
-        garageSaleBoardPart.spacing = 20
-        garageSaleBoardPart.distribution = .fillProportionally
-        garageSaleBoardPart.translatesAutoresizingMaskIntoConstraints = false
+        axis = .vertical
+        alignment = .leading
+        spacing = 20
+        distribution = .fillProportionally
+        translatesAutoresizingMaskIntoConstraints = false
         //        garageSaleBoardPart.backgroundColor = .orange
         
         
         let boardTitle = utils.boardTitle(partName: "중고장터")
-        garageSaleBoardPart.addArrangedSubview(boardTitle)
+        boardTitle.isUserInteractionEnabled = true
+        let tapGesture = BoardTapGesture(target: self, action: #selector(boardTapped(_:)))
+        tapGesture.data = "중고장터"
+        boardTitle.addGestureRecognizer(tapGesture)
+        
+        self.addArrangedSubview(boardTitle)
         
         let boardScrollView = UIScrollView()
         boardScrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -46,21 +51,39 @@ class GarageSalePartView: UIView {
         boardStackView.distribution = .fillEqually
         
         boardScrollView.addSubview(boardStackView)
-        garageSaleBoardPart.addArrangedSubview(boardScrollView)
-        contentView.addSubview(garageSaleBoardPart)
+        self.addArrangedSubview(boardScrollView)
+        contentView.addSubview(self)
         
         var contents = api.getRecentGarageSalePost()
         
         for i in 0...6 {
             let contentView = utils.createGarageSaleContentView(imageName:contents[i][0], text: contents[i][1])
+            
+            if (i < 6) {
+                contentView.isUserInteractionEnabled = true
+                let tapGestureLabel = BoardTapGesture(target: self, action: #selector(labelTapped(_:)))
+                tapGestureLabel.data = contents[i][1]
+                contentView.addGestureRecognizer(tapGestureLabel)
+                
+                boardStackView.addArrangedSubview(contentView)
+            }
+            else{
+                contentView.isUserInteractionEnabled = true
+                let tapGestureLabel = BoardTapGesture(target: self, action: #selector(boardTapped(_:)))
+                tapGestureLabel.data = "중고장터"
+                contentView.addGestureRecognizer(tapGestureLabel)
+                
+                boardStackView.addArrangedSubview(contentView)
+            }
+            
             boardStackView.addArrangedSubview(contentView)
         }
         
         
         
         NSLayoutConstraint.activate([
-            boardScrollView.leadingAnchor.constraint(equalTo: garageSaleBoardPart.leadingAnchor),
-            boardScrollView.trailingAnchor.constraint(equalTo: garageSaleBoardPart.trailingAnchor),
+            boardScrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            boardScrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             boardScrollView.topAnchor.constraint(equalTo: boardTitle.bottomAnchor, constant: 30),
             boardScrollView.heightAnchor.constraint(equalToConstant: 150),
             
@@ -71,11 +94,26 @@ class GarageSalePartView: UIView {
             boardStackView.heightAnchor.constraint(equalTo: boardScrollView.heightAnchor),
             boardStackView.widthAnchor.constraint(equalToConstant: 700),
             
-            garageSaleBoardPart.topAnchor.constraint(equalTo: belowView.bottomAnchor, constant: 30),
-            garageSaleBoardPart.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            garageSaleBoardPart.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            self.topAnchor.constraint(equalTo: belowView.bottomAnchor, constant: 30),
+            self.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            self.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             
         ])
+    }
+    
+    @objc func boardTapped(_ sender : BoardTapGesture) {
+        print("board garageSale clicked")
+
+        if let data = sender.data {
+            navigateDelegate?.navigateToBoardListPage(with: data)
+        }
+    }
+    
+    @objc func labelTapped(_ sender : BoardTapGesture) {
+        print("boardGarageSlae detail clicked")
         
+        if let data = sender.data {
+            navigateDelegate?.navigateToBoardDetailPage(with: data)
+        }
     }
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/InteriorPartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/InteriorPartView.swift
@@ -29,7 +29,6 @@ class InteriorPartView: UIView {
         interiorBoardPart.spacing = 20
         interiorBoardPart.distribution = .fillProportionally
         interiorBoardPart.translatesAutoresizingMaskIntoConstraints = false
-        //        interiorBoardPart.backgroundColor = .orange
         
         
         let boardTitle = utils.boardTitle(partName: "오늘의 홈테리어")
@@ -38,7 +37,9 @@ class InteriorPartView: UIView {
         tapGesture.data = "오늘의 홈테리어"
         boardTitle.addGestureRecognizer(tapGesture)
         
+        
         interiorBoardPart.addArrangedSubview(boardTitle)
+        
         
         let boardScrollView = UIScrollView()
         boardScrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -111,16 +112,14 @@ class InteriorPartView: UIView {
     @objc func boardTapped(_ sender : BoardTapGesture) {
         print("board Interior clicked")
         
-        print(sender.data)
         if let data = sender.data {
-            
             navigateDelegate?.navigateToBoardListPage(with: data)
         }
     }
     
     @objc func labelTapped(_ sender : BoardTapGesture) {
         print("boardInterior detail clicked")
-     
+        
         if let data = sender.data {
             navigateDelegate?.navigateToBoardDetailPage(with: data)
         }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/InteriorPartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/InteriorPartView.swift
@@ -10,6 +10,7 @@ import UIKit
 class InteriorPartView: UIView {
     let utils = MainPageCommonUtils()
     let api = RequestApi()
+    weak var navigateDelegate : NavigationDelegate?
     
     init(contentView: UIView, belowView: UIView) {
         super.init(frame: .zero)
@@ -32,6 +33,11 @@ class InteriorPartView: UIView {
         
         
         let boardTitle = utils.boardTitle(partName: "오늘의 홈테리어")
+        boardTitle.isUserInteractionEnabled = true
+        let tapGesture = BoardTapGesture(target: self , action: #selector(boardTapped(_:)))
+        tapGesture.data = "오늘의 홈테리어"
+        boardTitle.addGestureRecognizer(tapGesture)
+        
         interiorBoardPart.addArrangedSubview(boardTitle)
         
         let boardScrollView = UIScrollView()
@@ -55,7 +61,26 @@ class InteriorPartView: UIView {
         var contents = api.getRecentInteriorPost()
         
         for i in 0...6 {
+            
             let contentView = utils.createInteriorContentView(imageName:contents[i][0], text: contents[i][1])
+            
+            if (i < 6) {
+                contentView.isUserInteractionEnabled = true
+                let tapGestureLabel = BoardTapGesture(target: self, action: #selector(labelTapped(_:)))
+                tapGestureLabel.data = contents[i][1]
+                contentView.addGestureRecognizer(tapGestureLabel)
+                
+                boardStackView.addArrangedSubview(contentView)
+            }
+            else{
+                contentView.isUserInteractionEnabled = true
+                let tapGestureLabel = BoardTapGesture(target: self, action: #selector(boardTapped(_:)))
+                tapGestureLabel.data = "오늘의 홈테리어"
+                contentView.addGestureRecognizer(tapGestureLabel)
+                
+                boardStackView.addArrangedSubview(contentView)
+            }
+            
             boardStackView.addArrangedSubview(contentView)
         }
         
@@ -81,5 +106,23 @@ class InteriorPartView: UIView {
             interiorBoardPart.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
             
         ])
+    }
+    
+    @objc func boardTapped(_ sender : BoardTapGesture) {
+        print("board Interior clicked")
+        
+        print(sender.data)
+        if let data = sender.data {
+            
+            navigateDelegate?.navigateToBoardListPage(with: data)
+        }
+    }
+    
+    @objc func labelTapped(_ sender : BoardTapGesture) {
+        print("boardInterior detail clicked")
+     
+        if let data = sender.data {
+            navigateDelegate?.navigateToBoardDetailPage(with: data)
+        }
     }
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/TopPartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/TopPartView.swift
@@ -124,7 +124,6 @@ class TopPartView: UIView, UIGestureRecognizerDelegate {
         titlePart.alignment = .center
         titlePart.distribution = .equalCentering
         titlePart.translatesAutoresizingMaskIntoConstraints = false
-        //        titlePart.backgroundColor = .systemPink
         
         
         let popularIcon = UIImageView()

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/TopPartView.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/MainPageViews/TopPartView.swift
@@ -7,9 +7,10 @@
 
 import UIKit
 
-class TopPartView: UIView {
+class TopPartView: UIView, UIGestureRecognizerDelegate {
     let api = RequestApi()
     var popularPosts : [String] = []
+    weak var navigationDelegate : NavigationDelegate?
     
     init(contentView: UIView) {
         super.init(frame: .zero)
@@ -32,11 +33,10 @@ class TopPartView: UIView {
         topPartStackView.isLayoutMarginsRelativeArrangement = true
         
         
-        let topPartContainerView = UIView()
-        topPartContainerView.translatesAutoresizingMaskIntoConstraints = false
-        topPartContainerView.layer.borderColor = UIColor.gray.withAlphaComponent(0.3).cgColor
-        topPartContainerView.layer.borderWidth = 2.0
-        topPartContainerView.layer.cornerRadius = 20.0
+        translatesAutoresizingMaskIntoConstraints = false
+        layer.borderColor = UIColor.gray.withAlphaComponent(0.3).cgColor
+        layer.borderWidth = 2.0
+        layer.cornerRadius = 20.0
         
         
         let popularBoardPart = UIStackView()
@@ -56,11 +56,17 @@ class TopPartView: UIView {
         
         
         popularPosts = api.getPopularPosts()
-        for title in popularPosts {
+        for postTitle in popularPosts {
             let titleLabel = UILabel()
-            titleLabel.text = title
+            titleLabel.text = postTitle
             titleLabel.font = UIFont.systemFont(ofSize: 11)
             titleLabel.textColor = UIColor(hexCode: "5D5D5D")
+            
+            titleLabel.isUserInteractionEnabled = true
+            let tapGestureLabel = BoardTapGesture(target : self, action : #selector(labelTapped(_:)))
+            tapGestureLabel.data = postTitle
+            titleLabel.addGestureRecognizer(tapGestureLabel)
+            
             popularBoardListPart.addArrangedSubview(titleLabel)
         }
         
@@ -86,20 +92,24 @@ class TopPartView: UIView {
         
         topPartStackView.addArrangedSubview(maintenancePart)
         
-        topPartContainerView.addSubview(topPartStackView)
-        contentView.addSubview(topPartContainerView)
+        self.addSubview(topPartStackView)
+        contentView.addSubview(self)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(stackViewTapped))
+        tapGesture.cancelsTouchesInView = false
+        maintenancePart.addGestureRecognizer(tapGesture)
         
         
         
         NSLayoutConstraint.activate([
-            topPartContainerView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 30),
-            topPartContainerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
-            topPartContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15),
-            topPartContainerView.bottomAnchor.constraint(equalTo: topPartStackView.bottomAnchor, constant: 20),
+            self.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 30),
+            self.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            self.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15),
+            self.bottomAnchor.constraint(equalTo: topPartStackView.bottomAnchor, constant: 20),
             
-            topPartStackView.topAnchor.constraint(equalTo: topPartContainerView.topAnchor, constant: 30),
-            topPartStackView.leadingAnchor.constraint(equalTo: topPartContainerView.leadingAnchor, constant: 20),
-            topPartStackView.trailingAnchor.constraint(equalTo: topPartContainerView.trailingAnchor, constant: -20),
+            topPartStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 30),
+            topPartStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            topPartStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
             
             
             popularBoardListPart.leadingAnchor.constraint(equalTo: topPartStackView.leadingAnchor, constant: 20)
@@ -131,5 +141,17 @@ class TopPartView: UIView {
         
         
         return titlePart
+    }
+    
+    @objc func labelTapped(_ sender: BoardTapGesture) {
+        print("toppart label clicked")
+        if let data = sender.data {
+            navigationDelegate?.navigateToBoardDetailPage(with: data)
+        }
+    }
+    
+    @objc func stackViewTapped() {
+        print("toppart stackView clicked")
+        navigationDelegate?.navigateToNextPage()
     }
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/TabBarController.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/TabBarController.swift
@@ -41,7 +41,11 @@ class TabBarController: UITabBarController {
         let nav2 = UINavigationController(rootViewController: vc2)
         let nav3 = UINavigationController(rootViewController: vc3)
         
-        setViewControllers([nav1, nav2, nav3], animated: false)
+        nav1.tabBarItem = UITabBarItem(title: nil, image: originalImage1, selectedImage: selectedImage1)
+        nav2.tabBarItem = UITabBarItem(title: nil, image: originalImage2, selectedImage: selectedImage2)
+        nav3.tabBarItem = UITabBarItem(title: nil, image: originalImage3, selectedImage: selectedImage3)
+        
+        self.viewControllers = [nav1, nav2, nav3]
     }
     
     func setupStyle() {

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/Utils/MainPageCommonUtils.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/Utils/MainPageCommonUtils.swift
@@ -16,7 +16,6 @@ class MainPageCommonUtils {
         titlePart.alignment = .center
         titlePart.distribution = .equalCentering
         titlePart.translatesAutoresizingMaskIntoConstraints = false
-        //        titlePart.backgroundColor = .systemPink
         
         titlePart.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right:0)
         titlePart.isLayoutMarginsRelativeArrangement = true

--- a/HelloThere_UIKit/HelloThere_UIKit/MainViews/Utils/MainPageCommonUtils.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/MainViews/Utils/MainPageCommonUtils.swift
@@ -164,7 +164,4 @@ class MainPageCommonUtils {
         
         return smallBoard
     }
-    
-    
-    
 }

--- a/HelloThere_UIKit/HelloThere_UIKit/Protocols/NavigationDelegate.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/Protocols/NavigationDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  NavigationDelegate.swift
+//  HelloThere_UIKit
+//
+//  Created by 임정현 on 2024/08/19.
+//
+
+import UIKit
+
+class BoardTapGesture : UITapGestureRecognizer {
+    var data : String?
+}
+
+protocol NavigationDelegate : AnyObject {
+    func navigateToNextPage()
+    func navigateToBoardDetailPage(with title : String)
+    // 현재는 직접 게시글에 대한 제목을 넘겨주지만 api로 연동하는 경우 고유의 게시글의 번호 등을 통해 게시글 구분
+    // 게시글 페이지
+    func navigateToBoardListPage(with boardName : String)
+    // 게시판 리스트 페이지
+}

--- a/HelloThere_UIKit/HelloThere_UIKit/SceneDelegate.swift
+++ b/HelloThere_UIKit/HelloThere_UIKit/SceneDelegate.swift
@@ -17,11 +17,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         
-        guard let scene = (scene as? UIWindowScene) else { return }
-        window = UIWindow(frame : scene.coordinateSpace.bounds)
-        window?.windowScene = scene
-        window?.rootViewController = ViewController()
-        window?.makeKeyAndVisible()
+//        guard let scene = (scene as? UIWindowScene) else { return }
+//        window = UIWindow(frame : scene.coordinateSpace.bounds)
+//        window?.windowScene = scene
+//        window?.rootViewController = ViewController()
+//        window?.makeKeyAndVisible()
+        
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        let window = UIWindow(windowScene: windowScene)
+           
+           // ViewController를 첫 번째 화면으로 설정
+           let viewController = ViewController()
+           let navigationController = UINavigationController(rootViewController: viewController)
+           
+           window.rootViewController = navigationController
+           self.window = window
+           window.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
작업한 내용

- 더보기 기능
- 인기 게시물에서 각각의 게시물 제목을 클릭하면 게시물 디테일 페이지로 이동가능하도록 탭 제스처 추가
- 이달의 관리비 파트 UIStack을 탭하면 이달의 관리비 페이지로 이동하도록 탭 제스처 추가
- 주민 게시판 내 게시판 이름을 클릭하면 게시판 내 게시물 리스트 목록이 뜨는 페이지로 이동하도록 탭 제스처 추가
- 오늘의 홈테리어 및 중고장터 게시판 이름 클릭시 게시물 리스트 목록이 뜨는 페이지로 이동하도록 탭 제스처 추가
- 오늘의 홈테리어 및 중고장터 게시물 클릭시 게시물 디테일 페이지로 이동가능하도록 탭 제스처 추가
- 오늘의 홈테리어 및 중고장터 좌우 스크롤 시 더보기를 클릭하면 게시물 리스트 목록이 뜨는 페이지로 이동하도록 탭 제스처 추가

보충할 내용

- 검색하기 기능
- 알림 보기 기능